### PR TITLE
44: Ignore wildcards in outlier alerts to prevent breaking Datadog UI.

### DIFF
--- a/datadog/resource_datadog_outlier_alert.go
+++ b/datadog/resource_datadog_outlier_alert.go
@@ -104,6 +104,10 @@ func buildOutlierAlertStruct(d *schema.ResourceData, typeStr string) *datadog.Mo
 		list := raw.([]interface{})
 		length := (len(list) - 1)
 		for i, v := range list {
+			if v == "*" {
+				log.Print(fmt.Sprintf("[DEBUG] found wildcard, this is not supported for this type: %s", v))
+				continue
+			}
 			buffer.WriteString(fmt.Sprintf("%s", v))
 			if i != length {
 				buffer.WriteString(",")


### PR DESCRIPTION
Works around #44 