### PR TITLE
Add missing line to datadog_metric_alert README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ resource "datadog_service_check" "bar" {
 Example configuration:
 
 ``` HCL
+resource "datadog_metric_alert" "foo" {
   name = "CPU alert for {{host.name}}"
   message = "CPU alert failed on {{host.name}} in environment {{host.environment}}"
 


### PR DESCRIPTION
This is a quick README fixup that adds a missing line to the datadog_metric_alert example.