### PR TITLE
Add `query` parameter to `metric_alert`

### DIFF
--- a/datadog/resource_datadog_metric_alert_test.go
+++ b/datadog/resource_datadog_metric_alert_test.go
@@ -61,6 +61,43 @@ func TestAccDatadogMetricAlert_Basic(t *testing.T) {
 	})
 }
 
+func TestAccDatadogMetricAlert_Query(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDatadogMetricAlertDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckDatadogMetricAlertConfigQuery,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDatadogMetricAlertExists("datadog_metric_alert.foo"),
+					resource.TestCheckResourceAttr(
+						"datadog_metric_alert.foo", "name", "name for metric_alert foo"),
+					resource.TestCheckResourceAttr(
+						"datadog_metric_alert.foo", "message", "{{#is_alert}}Metric alert foo is critical"+
+							"{{/is_alert}}\n{{#is_warning}}Metric alert foo is at warning "+
+							"level{{/is_warning}}\n{{#is_recovery}}Metric alert foo has "+
+							"recovered{{/is_recovery}}\nNotify: @hipchat-channel\n"),
+					resource.TestCheckResourceAttr(
+						"datadog_metric_alert.foo", "query", "avg(last_1h):avg:aws.ec2.cpu{environment:foo,host:foo} by {host}"),
+					resource.TestCheckResourceAttr(
+						"datadog_metric_alert.foo", "operator", ">"),
+					resource.TestCheckResourceAttr(
+						"datadog_metric_alert.foo", "notify_no_data", "false"),
+					resource.TestCheckResourceAttr(
+						"datadog_metric_alert.foo", "renotify_interval", "60"),
+					resource.TestCheckResourceAttr(
+						"datadog_metric_alert.foo", "thresholds.ok", "0"),
+					resource.TestCheckResourceAttr(
+						"datadog_metric_alert.foo", "thresholds.warning", "1"),
+					resource.TestCheckResourceAttr(
+						"datadog_metric_alert.foo", "thresholds.critical", "2"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckDatadogMetricAlertDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*datadog.Client)
 
@@ -98,6 +135,28 @@ EOF
   time_window = "last_1h" // last_#m (5, 10, 15, 30), last_#h (1, 2, 4), or last_1d
   space_aggr = "avg" // avg, sum, min, or max
   operator = ">" // <, <=, >, >=, ==, or !=
+
+  thresholds {
+	ok = 0
+	warning = 1
+	critical = 2
+  }
+
+  notify_no_data = false
+  renotify_interval = 60
+}
+`
+const testAccCheckDatadogMetricAlertConfigQuery = `
+resource "datadog_metric_alert" "foo" {
+  name = "name for metric_alert foo"
+  message           = <<EOF
+{{#is_alert}}Metric alert foo is critical{{/is_alert}}
+{{#is_warning}}Metric alert foo is at warning level{{/is_warning}}
+{{#is_recovery}}Metric alert foo has recovered{{/is_recovery}}
+Notify: @hipchat-channel
+EOF
+  operator = ">" // <, <=, >, >=, ==, or !=
+  query = "avg(last_1h):avg:aws.ec2.cpu{environment:foo,host:foo} by {host}"
 
   thresholds {
 	ok = 0


### PR DESCRIPTION
`query` is used when it is specified by the user, if not
`metric`/`tags`/`keys`/`time_aggr`/`window` is used instead.